### PR TITLE
Fix build of uunf.cmxs

### DIFF
--- a/src/uunf.mldylib
+++ b/src/uunf.mldylib
@@ -1,0 +1,5 @@
+Uunf_tmap
+Uunf_tmapbool
+Uunf_tmapbyte
+Uunf_data
+Uunf


### PR DESCRIPTION
File `uunf.mldylib` is needed for that. Otherwise, only `uunf.cmx` is included in the library.