### PR TITLE
Add missing dev dependencies

### DIFF
--- a/opam
+++ b/opam
@@ -10,7 +10,7 @@ license: ["ISC"]
 tags: ["unicode" "text" "normalization" "org:erratique"]
 depends: ["ocaml" {>= "4.03.0"}
           "xmlm" {dev}
-          "uucd" {dev}
+          "uucd" {dev & >= "13.0.0" & < 14.0.0}
           "ocamlfind" {build}
           "ocamlbuild" {build}
           "topkg" {build & >= "1.0.3"}]

--- a/opam
+++ b/opam
@@ -10,7 +10,7 @@ license: ["ISC"]
 tags: ["unicode" "text" "normalization" "org:erratique"]
 depends: ["ocaml" {>= "4.03.0"}
           "xmlm" {dev}
-          "uucd" {dev & >= "13.0.0" & < 14.0.0}
+          "uucd" {dev & >= "13.0.0" & < "14.0.0"}
           "ocamlfind" {build}
           "ocamlbuild" {build}
           "topkg" {build & >= "1.0.3"}]

--- a/opam
+++ b/opam
@@ -9,6 +9,8 @@ bug-reports: "https://github.com/dbuenzli/uunf/issues"
 license: ["ISC"]
 tags: ["unicode" "text" "normalization" "org:erratique"]
 depends: ["ocaml" {>= "4.03.0"}
+          "xmlm" {dev}
+          "uucd" {dev}
           "ocamlfind" {build}
           "ocamlbuild" {build}
           "topkg" {build & >= "1.0.3"}]


### PR DESCRIPTION
```
#=== ERROR while compiling uunf.13.0.0 ========================================#
# context              2.1.0 | linux/ppc64 | ocaml-base-compiler.4.12.0 | pinned(git+http://erratique.ch/repos/uunf.git#792a6528)
# path                 ~/.opam/4.12/.opam-switch/build/uunf.13.0.0
# command              ~/.opam/4.12/bin/ocaml pkg/pkg.ml build --dev-pkg true --with-uutf false --with-cmdliner false
# exit-code            1
# env-file             ~/.opam/log/uunf-1-063428.env
# output-file          ~/.opam/log/uunf-1-063428.out
### output ###
# ocamlfind ocamldep -package xmlm -package uucd -modules support/gen_props.ml > support/gen_props.ml.depends
# + ocamlfind ocamldep -package xmlm -package uucd -modules support/gen_props.ml > support/gen_props.ml.depends
# ocamlfind: Package `xmlm' not found
# Command exited with code 2.
# build_support.ml: [ERROR] cmd ['ocamlbuild' '-classic-display' '-no-links' '-use-ocamlfind'
#      'gen_props.native']: exited with 10
# pkg.ml: [ERROR] Pin distribution preparation failed: cmd ['ocaml' 'pkg/build_support.ml']: exited with 1
```